### PR TITLE
fix for timestamps

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -900,7 +900,7 @@ Import.prototype = {
 			startTime = +new Date();
 
 		async.eachLimit(this.mem._tids, 5, function(_tid, done) {
-			DB.getSortedSetRevRange('tid:' + _tid + ':posts', function(err, pids) {
+			DB.getSortedSetRevRange('tid:' + _tid + ':posts', 0, -1, function(err, pids) {
 				if (err) {
 					return done(err);
 				}


### PR DESCRIPTION
needs latest nodebb, Posts.create takes in an timestamp now.

After all posts are added into the topics `fixTopicTimestamps` function will run and it will take the timestamp of the last post in each topic and update the topic's timestamp so category order is working correctly.
