### PR TITLE
Added nodebb-plugin-import-esotalk to the optionalDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
 		"nodebb-plugin-import-ubb": "*",
 		"nodebb-plugin-import-smf": "*",
 		"nodebb-plugin-import-wordpress": "*",
-		"nodebb-plugin-import-punbb": "*"
+		"nodebb-plugin-import-punbb": "*",
+		"nodebb-plugin-import-esotalk": "*"
 	},
     "nbbpm": {
         "compatibility": "^0.6.0"


### PR DESCRIPTION
As suggested, I wrote my own exporter by forking one of yours and adapting it as needed. It exports data from a rather esoteric forum software called esoTalk. I was having increasing problems with spam accounts, and thus decided to finally migrate to nodebb. The database structure of esoTalk is a bit strange, and so is this exporter plugin. It worked for me, and I hope no one else will ever need it, but nevertheless, here it is, just in case, you know.