### PR TITLE
fixes typo for label id

### DIFF
--- a/public/templates/admin/plugins/import.tpl
+++ b/public/templates/admin/plugins/import.tpl
@@ -126,7 +126,7 @@
 
             <div class="form-group">
                 <div class="checkbox">
-                    <label for="importer-admin-take-8ownership">
+                    <label for="importer-admin-take-ownership">
                         <input
                                 data-on="change"
                                 data-action="visibleToggle"


### PR DESCRIPTION
In a newer version of NodeBB, this value being a typo actually caused the checkbox to stop working