### PR TITLE
Remove fixPostsToPids.

### DIFF
--- a/server/data.js
+++ b/server/data.js
@@ -290,18 +290,6 @@ var async = require('async'),
 		return Data.each('posts:pid', 'post:', iterator, options, callback);
 	};
 
-  Data.eachOrphanedPost = function (iterator, options, callback) {
-    return Data.each('posts:pid', 'post:', iterator, nodeExtend(true,
-      {where: {
-        fields: {
-          _imported_toPid: {exists: true, ne: ''},
-          _imported_pid: {exists: true, ne: ''},
-          pid: {exists: true},
-          toPid: {exists: false}
-        }
-      }}, options), callback);
-  };
-
   Data.eachImportedUser = function(iterator, options, callback) {
 		return Data.each('_imported:_users', '_imported_user:', iterator, options, callback);
 	};


### PR DESCRIPTION
Set post.toPid when it is being initially inserted. This requires adapters to import posts before their replies (usually this means sorting by ID or timestamp). See #174.