### PR TITLE
finally fix for wrong sorted pinned topics

### DIFF
--- a/server/importer.js
+++ b/server/importer.js
@@ -2656,7 +2656,7 @@ var async = require('async'),
             },
 
             timestamps: function (done) {
-              if (!topic || !topic.tid)
+              if (!topic || !topic.tid || topic.pinned)
                 return done();
 
               // todo paginate this as well


### PR DESCRIPTION
In some cases pinned topics weren't sorted correct like described in #161 . The 2^ 53 timestamp has been changed back to the original one through "Importer.fixTopicTimestampsAndRelockLockedTopics".

I couldn't find the proper reason why some topics had the correct and some the wrong timestamps, but I also haven't seen any side effects from the fix I'm providing.